### PR TITLE
Update MaterialTextView.podspec

### DIFF
--- a/MaterialTextView.podspec
+++ b/MaterialTextView.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/qiwi/MaterialTextView' }
   s.framework = "UIKit"
   s.source_files = 'MaterialTextView/*.swift'
-  s.dependency 'https://github.com/qiwi/FormattableTextView'
+  s.dependency 'FormattableTextView'
 end

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Placeholder has 2 modes: animatable and normal.
 
 ### CocoaPods
 ```
+pod 'FormattableTextView', :git => 'https://github.com/qiwi/FormattableTextView'
 pod 'MaterialTextView', :git => 'https://github.com/qiwi/MaterialTextView'
 ```
 


### PR DESCRIPTION
Не работает pod install, вот такая ошибка:

```
[!] Unable to find a specification for `https://github.com/qiwi/FormattableTextView` depended upon by `MaterialTextView`

You have either:
 * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.

Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.
```

Предлагаю в podspec указать только название зависимости, а тот кто будет использовать вашу либу в своем проекте в свой Podfile добавит еще и зависимый pod
Вот мой podfile, который работает:

```
target 'MyTarget' do
  use_frameworks!

  pod 'FormattableTextView', :git => 'https://github.com/qiwi/FormattableTextView'
  pod 'MaterialTextView', :git => 'https://github.com/majorpein/MaterialTextView'
end
```