### PR TITLE
Add @discardableResult for becomeFirstResponder to hide warning

### DIFF
--- a/MaterialTextView/MaterialTextView.swift
+++ b/MaterialTextView/MaterialTextView.swift
@@ -233,6 +233,7 @@ public final class MaterialTextView: UIView, MaterialTextViewProtocol {
 		textViewToRightButtonConstraint.isActive = true
 	}
 	
+    @discardableResult
 	override public func becomeFirstResponder() -> Bool {
 		return textComponentInternal.becomeFirstResponder()
 	}


### PR DESCRIPTION
Предлагаю добавить чтобы избавить от такой записи:

```Swift
_ = self.field.becomeFirstResponder()
```